### PR TITLE
Fix hash generation to check if image was already resized

### DIFF
--- a/image_tag.rb
+++ b/image_tag.rb
@@ -107,8 +107,8 @@ module Jekyll
       end
 
       image = MiniMagick::Image.open(image_source_path)
-      image.coalesce
-      digest = Digest::MD5.hexdigest(image.to_blob).slice!(0..5)
+      digest = Digest::MD5.file image_source_path
+      digest = digest.hexdigest.slice!(0..5)
 
       image_dir = File.dirname(instance[:src])
       ext = File.extname(instance[:src])


### PR DESCRIPTION
Old implementation did created different md5 hashes for the same image. So the images got regenerated on every jekyll build.